### PR TITLE
Added support for fontFamily array

### DIFF
--- a/src/type.js
+++ b/src/type.js
@@ -40,7 +40,9 @@ module.exports = function type({ theme, addComponents, e }) {
     output[`.${className}`].fontSize = baseFontSize
     if (fontFamily) {
       output[`.${className}`].fontFamily =
-        fontFamily.constructor === Array ? fontFamily.join(', ') : fontFamily
+        fontFamily.constructor === Array
+          ? fontFamily.map(f => (/[^a-z-]/i.test(f) ? `"${f}"` : f)).join(', ')
+          : fontFamily
     }
     output = { ...output, ...responsiveFontSizeComponents }
   }

--- a/src/type.js
+++ b/src/type.js
@@ -5,7 +5,7 @@ module.exports = function type({ theme, addComponents, e }) {
   let output = {}
 
   for (let name of Object.keys(typeStyles)) {
-    let { fontSize, crop, ...props } = typeStyles[name]
+    let { fontSize, fontFamily, crop, ...props } = typeStyles[name]
     let className = e(`type-${name}`)
 
     output[`.${className}`] = {
@@ -38,6 +38,10 @@ module.exports = function type({ theme, addComponents, e }) {
     })
 
     output[`.${className}`].fontSize = baseFontSize
+    if (fontFamily) {
+      output[`.${className}`].fontFamily =
+        fontFamily.constructor === Array ? fontFamily.join(', ') : fontFamily
+    }
     output = { ...output, ...responsiveFontSizeComponents }
   }
 


### PR DESCRIPTION
Now supports fontFamily as an array

```js
fontFamily: ['Helvetica', 'sans-serif']
```

Before:
```css
font-family: Helvetica;
font-family: sans-serif;
```

After:
```css
font-family: Helvetica, sans-serif;
```